### PR TITLE
VAST validation

### DIFF
--- a/lib/vast/document.rb
+++ b/lib/vast/document.rb
@@ -36,7 +36,10 @@ module VAST
         return false
       end
       xsd = Nokogiri::XML::Schema(File.read(xsd_file))
-      xsd.valid?(self)
+      doc = Nokogiri.XML(self.to_s) do |config|
+        config.nocdata
+      end
+      xsd.validate(doc).empty?
     end
     
     # A single VAST response may include multiple Ads from multiple advertisers. It will be up to the 


### PR DESCRIPTION
some vast validation against xsd files failed because some data are within `CDATA` when xsd file expects URI for example.
Parse doc with nocdata option for validation


Will make sa-web to point to this repo after merging this PR